### PR TITLE
Add relatório module with data listing option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "modPlano.h"
 #include "modFuncionario.h"
 #include "modEquipamento.h"
+#include "modRelatorio.h"
 #include "telaSobre.h"
 #include "telaFinalizacao.h"
 #include "opInvalida.h"
@@ -59,6 +60,11 @@ int main(void)
             break;
 
         case '5':
+            moduloRelatorio();
+            limparTela();
+            break;
+
+        case '6':
             telaSobre();
             limparTela();
             break;

--- a/src/modRelatorio.h
+++ b/src/modRelatorio.h
@@ -1,0 +1,6 @@
+#ifndef MOD_RELATORIO_H
+#define MOD_RELATORIO_H
+
+char moduloRelatorio(void);
+
+#endif

--- a/src/ui/relatorio/listagemDados.c
+++ b/src/ui/relatorio/listagemDados.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+
+#include "limparTela.h"
+#include "src/ui/aluno/cadastrarAluno.h"
+#include "src/ui/plano/cadastrarPlano.h"
+#include "src/ui/funcionario/cadastrarFuncionario.h"
+#include "src/ui/equipamento/cadastrarEquipamento.h"
+
+void relatorioListagemDados(void)
+{
+    limparTela();
+
+    printf("=========================================================================\n");
+    printf("===                 RELATÓRIO - LISTAGEM DE DADOS                     ===\n");
+    printf("=========================================================================\n\n");
+
+    int alunos_ativos = 0;
+    for (int i = 0; i < total_alunos; i++)
+    {
+        if (lista_alunos[i].ativo)
+        {
+            alunos_ativos++;
+        }
+    }
+    printf("ALUNOS ATIVOS: %d\n", alunos_ativos);
+    if (alunos_ativos > 0)
+    {
+        for (int i = 0; i < total_alunos; i++)
+        {
+            if (lista_alunos[i].ativo)
+            {
+                printf("  - [%s] %s\n", lista_alunos[i].id, lista_alunos[i].nome);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum aluno ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int planos_ativos = 0;
+    for (int i = 0; i < total_planos; i++)
+    {
+        if (lista_planos[i].ativo)
+        {
+            planos_ativos++;
+        }
+    }
+    printf("PLANOS ATIVOS: %d\n", planos_ativos);
+    if (planos_ativos > 0)
+    {
+        for (int i = 0; i < total_planos; i++)
+        {
+            if (lista_planos[i].ativo)
+            {
+                printf("  - [%s] %s\n", lista_planos[i].id, lista_planos[i].nome);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum plano ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int funcionarios_ativos = 0;
+    for (int i = 0; i < total_funcionarios; i++)
+    {
+        if (lista_funcionarios[i].ativo)
+        {
+            funcionarios_ativos++;
+        }
+    }
+    printf("FUNCIONÁRIOS ATIVOS: %d\n", funcionarios_ativos);
+    if (funcionarios_ativos > 0)
+    {
+        for (int i = 0; i < total_funcionarios; i++)
+        {
+            if (lista_funcionarios[i].ativo)
+            {
+                printf("  - [%s] %s (%s)\n", lista_funcionarios[i].id, lista_funcionarios[i].nome, lista_funcionarios[i].cargo);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum funcionário ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int equipamentos_ativos = 0;
+    for (int i = 0; i < total_equipamentos; i++)
+    {
+        if (lista_equipamentos[i].ativo)
+        {
+            equipamentos_ativos++;
+        }
+    }
+    printf("EQUIPAMENTOS ATIVOS: %d\n", equipamentos_ativos);
+    if (equipamentos_ativos > 0)
+    {
+        for (int i = 0; i < total_equipamentos; i++)
+        {
+            if (lista_equipamentos[i].ativo)
+            {
+                printf("  - [%s] %s - Próx. manutenção: %s\n", lista_equipamentos[i].id, lista_equipamentos[i].nome, lista_equipamentos[i].proxima_manutencao);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum equipamento ativo encontrado.\n");
+    }
+
+    printf("\n=========================================================================\n");
+    printf(">>> Pressione <ENTER> para voltar...");
+    getchar();
+
+    limparTela();
+}

--- a/src/ui/relatorio/listagemDados.h
+++ b/src/ui/relatorio/listagemDados.h
@@ -1,0 +1,6 @@
+#ifndef LISTAGEM_DADOS_H
+#define LISTAGEM_DADOS_H
+
+void relatorioListagemDados(void);
+
+#endif

--- a/src/ui/relatorio/modRelatorio.c
+++ b/src/ui/relatorio/modRelatorio.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+#include "telaRelatorio.h"
+#include "listagemDados.h"
+#include "opInvalida.h"
+
+char moduloRelatorio(void)
+{
+    char op;
+
+    do
+    {
+        op = telaRelatorio();
+
+        switch (op)
+        {
+        case '1':
+            relatorioListagemDados();
+            break;
+
+        case '0':
+            break;
+
+        default:
+            opInvalida();
+            break;
+        }
+
+    } while (op != '0');
+
+    return op;
+}

--- a/src/ui/relatorio/telaRelatorio.c
+++ b/src/ui/relatorio/telaRelatorio.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+#include "limparTela.h"
+
+char telaRelatorio(void)
+{
+    char op;
+
+    printf("\n");
+    printf("=========================================================================\n");
+    printf("===                          RELATÓRIOS                               ===\n");
+    printf("=========================================================================\n");
+    printf("===                                                                   ===\n");
+    printf("===  [1]  RELATÓRIO DE LISTAGEM DE DADOS                              ===\n");
+    printf("===                                                                   ===\n");
+    printf("===  [0]  VOLTAR                                                      ===\n");
+    printf("===                                                                   ===\n");
+    printf("=========================================================================\n");
+    printf("=========================================================================\n");
+
+    scanf("%c", &op);
+    getchar();
+
+    limparTela();
+
+    return op;
+}

--- a/src/ui/relatorio/telaRelatorio.h
+++ b/src/ui/relatorio/telaRelatorio.h
@@ -1,0 +1,6 @@
+#ifndef TELA_RELATORIO_H
+#define TELA_RELATORIO_H
+
+char telaRelatorio(void);
+
+#endif

--- a/src/ui/telaPrincipal.c
+++ b/src/ui/telaPrincipal.c
@@ -16,7 +16,8 @@ char telaPrincipal(void)
     printf("===  [2]  PLANOS                                                      ===\n");
     printf("===  [3]  EQUIPAMENTOS                                                ===\n");
     printf("===  [4]  FUNCIONARIOS                                                ===\n");
-    printf("===  [5]  SOBRE                                                       ===\n");
+    printf("===  [5]  RELATORIOS                                                  ===\n");
+    printf("===  [6]  SOBRE                                                       ===\n");
     printf("===  [0]  SAIR                                                        ===\n");
     printf("===                                                                   ===\n");
     printf("=========================================================================\n");


### PR DESCRIPTION
## Summary
- add a relatório module alongside the existing main modules
- implement a data listing report showing active alunos, planos, funcionários and equipamentos
- update the home menu to expose the relatório option

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691277ba3938832b9041dcafd9d45a3e)