### PR TITLE
Seed default data for relatório listagem

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "modPlano.h"
 #include "modFuncionario.h"
 #include "modEquipamento.h"
+#include "modRelatorio.h"
 #include "telaSobre.h"
 #include "telaFinalizacao.h"
 #include "opInvalida.h"
@@ -59,6 +60,11 @@ int main(void)
             break;
 
         case '5':
+            moduloRelatorio();
+            limparTela();
+            break;
+
+        case '6':
             telaSobre();
             limparTela();
             break;

--- a/src/modRelatorio.h
+++ b/src/modRelatorio.h
@@ -1,0 +1,6 @@
+#ifndef MOD_RELATORIO_H
+#define MOD_RELATORIO_H
+
+char moduloRelatorio(void);
+
+#endif

--- a/src/ui/aluno/arquivoAluno.c
+++ b/src/ui/aluno/arquivoAluno.c
@@ -9,6 +9,54 @@
 #define ALUNOS_FILE "alunos.dat"
 #define TMP_FILE    "alunos.tmp"
 
+static int preencherAlunosFicticios(struct aluno lista_alunos[])
+{
+    static const struct aluno alunos_iniciais[] = {
+        {
+            .id = "ALU-0001",
+            .nome = "João Silva",
+            .idade = "29",
+            .cpf = "123.456.789-00",
+            .telefone = "(11) 99876-5432",
+            .endereco = "Rua das Palmeiras, 120 - Centro",
+            .email = "joao.silva@example.com",
+            .ativo = true,
+            .plano_id = "PLAN-001",
+        },
+        {
+            .id = "ALU-0002",
+            .nome = "Maria Souza",
+            .idade = "34",
+            .cpf = "987.654.321-00",
+            .telefone = "(11) 91234-5678",
+            .endereco = "Av. Brasil, 45 - Jardim Europa",
+            .email = "maria.souza@example.com",
+            .ativo = true,
+            .plano_id = "PLAN-002",
+        },
+        {
+            .id = "ALU-0003",
+            .nome = "Carlos Pereira",
+            .idade = "41",
+            .cpf = "321.654.987-00",
+            .telefone = "(11) 97777-1122",
+            .endereco = "Rua do Sol, 88 - Vila Nova",
+            .email = "carlos.pereira@example.com",
+            .ativo = true,
+            .plano_id = "PLAN-003",
+        },
+    };
+
+    int total = sizeof(alunos_iniciais) / sizeof(alunos_iniciais[0]);
+
+    for (int i = 0; i < total; i++)
+    {
+        lista_alunos[i] = alunos_iniciais[i];
+    }
+
+    return total;
+}
+
 // Salva todos os alunos ativos no arquivo binário
 void salvarAlunos(struct aluno lista_alunos[], int total_alunos) {
     // ALTERAÇÃO: Abrimos o arquivo em modo "wb" (write binary)
@@ -37,8 +85,9 @@ int carregarAlunos(struct aluno lista_alunos[]) {
     // ALTERAÇÃO: Abrimos o arquivo em modo "rb" (read binary)
     FILE *fp = fopen(ALUNOS_FILE, "rb");
     if (!fp) {
-        // Se o arquivo não existe, não há alunos para carregar.
-        return 0;
+        int total = preencherAlunosFicticios(lista_alunos);
+        salvarAlunos(lista_alunos, total);
+        return total;
     }
 
     int total = 0;

--- a/src/ui/equipamento/arquivoEquipamento.c
+++ b/src/ui/equipamento/arquivoEquipamento.c
@@ -9,6 +9,45 @@
 #define EQUIPAMENTOS_FILE "equipamentos.dat"
 #define TMP_FILE_EQUIP "equipamentos.tmp"
 
+static int preencherEquipamentosFicticios(struct equipamento lista_equipamentos[])
+{
+    static const struct equipamento equipamentos_iniciais[] = {
+        {
+            .id = "EQUIP-001",
+            .nome = "Esteira Pro Runner",
+            .ultima_manutencao = "10/01/2024",
+            .proxima_manutencao = "10/07/2024",
+            .categoria = "Cardio",
+            .ativo = true,
+        },
+        {
+            .id = "EQUIP-002",
+            .nome = "Bicicleta Spinning X3",
+            .ultima_manutencao = "20/02/2024",
+            .proxima_manutencao = "20/08/2024",
+            .categoria = "Cardio",
+            .ativo = true,
+        },
+        {
+            .id = "EQUIP-003",
+            .nome = "Leg Press 45º",
+            .ultima_manutencao = "05/03/2024",
+            .proxima_manutencao = "05/09/2024",
+            .categoria = "Musculação",
+            .ativo = true,
+        },
+    };
+
+    int total = sizeof(equipamentos_iniciais) / sizeof(equipamentos_iniciais[0]);
+
+    for (int i = 0; i < total; i++)
+    {
+        lista_equipamentos[i] = equipamentos_iniciais[i];
+    }
+
+    return total;
+}
+
 // Salva todos os equipamentos ativos no arquivo binário
 void salvarEquipamentos(struct equipamento lista_equipamentos[], int total_equipamentos)
 {
@@ -37,7 +76,11 @@ int carregarEquipamentos(struct equipamento lista_equipamentos[])
 {
     FILE *fp = fopen(EQUIPAMENTOS_FILE, "rb");
     if (!fp)
-        return 0;
+    {
+        int total = preencherEquipamentosFicticios(lista_equipamentos);
+        salvarEquipamentos(lista_equipamentos, total);
+        return total;
+    }
 
     int total = 0;
 

--- a/src/ui/funcionario/arquivoFuncionario.c
+++ b/src/ui/funcionario/arquivoFuncionario.c
@@ -9,6 +9,57 @@
 #define FUNCIONARIOS_FILE "funcionarios.dat"
 #define TMP_FILE_FUNC "funcionarios.tmp"
 
+static int preencherFuncionariosFicticios(struct funcionario lista_funcionarios[])
+{
+    static const struct funcionario funcionarios_iniciais[] = {
+        {
+            .id = "FUNC-001",
+            .nome = "Ana Martins",
+            .nascimento = "15/03/1990",
+            .idade = 34,
+            .cpf = "111.222.333-44",
+            .telefone = "(11) 90001-2233",
+            .endereco = "Rua das Acácias, 15 - Centro",
+            .email = "ana.martins@example.com",
+            .cargo = "Instrutora",
+            .ativo = true,
+        },
+        {
+            .id = "FUNC-002",
+            .nome = "Bruno Carvalho",
+            .nascimento = "08/09/1985",
+            .idade = 39,
+            .cpf = "555.666.777-88",
+            .telefone = "(11) 91122-3344",
+            .endereco = "Av. Paulista, 900 - Bela Vista",
+            .email = "bruno.carvalho@example.com",
+            .cargo = "Personal",
+            .ativo = true,
+        },
+        {
+            .id = "FUNC-003",
+            .nome = "Clara Nogueira",
+            .nascimento = "22/11/1995",
+            .idade = 28,
+            .cpf = "999.888.777-66",
+            .telefone = "(11) 98888-7766",
+            .endereco = "Rua das Flores, 300 - Vila Mariana",
+            .email = "clara.nogueira@example.com",
+            .cargo = "Nutricionista",
+            .ativo = true,
+        },
+    };
+
+    int total = sizeof(funcionarios_iniciais) / sizeof(funcionarios_iniciais[0]);
+
+    for (int i = 0; i < total; i++)
+    {
+        lista_funcionarios[i] = funcionarios_iniciais[i];
+    }
+
+    return total;
+}
+
 // Salva todos os funcionários ativos no arquivo binário
 void salvarFuncionarios(struct funcionario lista_funcionarios[], int total_funcionarios)
 {
@@ -38,7 +89,11 @@ int carregarFuncionarios(struct funcionario lista_funcionarios[])
 {
     FILE *fp = fopen(FUNCIONARIOS_FILE, "rb");
     if (!fp)
-        return 0;
+    {
+        int total = preencherFuncionariosFicticios(lista_funcionarios);
+        salvarFuncionarios(lista_funcionarios, total);
+        return total;
+    }
 
     int total = 0;
 

--- a/src/ui/plano/arquivoPlano.c
+++ b/src/ui/plano/arquivoPlano.c
@@ -8,6 +8,60 @@
 #define PLANOS_FILE "planos.dat"
 #define TMP_FILE "planos.tmp"
 
+static int preencherPlanosFicticios(struct plano lista_planos[])
+{
+    static const struct plano planos_iniciais[] = {
+        {
+            .id = "PLAN-001",
+            .nome = "Plano Performance",
+            .horario_inicio = "06:00",
+            .horario_fim = "10:00",
+            .atividades = {
+                "Musculação",
+                "Funcional",
+                "Cardio HIIT",
+            },
+            .total_atividades = 3,
+            .ativo = true,
+        },
+        {
+            .id = "PLAN-002",
+            .nome = "Plano Bem-Estar",
+            .horario_inicio = "10:00",
+            .horario_fim = "14:00",
+            .atividades = {
+                "Pilates",
+                "Alongamento",
+                "Yoga",
+            },
+            .total_atividades = 3,
+            .ativo = true,
+        },
+        {
+            .id = "PLAN-003",
+            .nome = "Plano Premium",
+            .horario_inicio = "16:00",
+            .horario_fim = "22:00",
+            .atividades = {
+                "Cross Training",
+                "Spinning",
+                "Natação",
+            },
+            .total_atividades = 3,
+            .ativo = true,
+        },
+    };
+
+    int total = sizeof(planos_iniciais) / sizeof(planos_iniciais[0]);
+
+    for (int i = 0; i < total; i++)
+    {
+        lista_planos[i] = planos_iniciais[i];
+    }
+
+    return total;
+}
+
 // Salva todos os planos ativos no arquivo binário
 void salvarPlanos(struct plano lista_planos[], int total_planos)
 {
@@ -37,7 +91,11 @@ int carregarPlanos(struct plano lista_planos[])
 {
     FILE *fp = fopen(PLANOS_FILE, "rb");
     if (!fp)
-        return 0;
+    {
+        int total = preencherPlanosFicticios(lista_planos);
+        salvarPlanos(lista_planos, total);
+        return total;
+    }
 
     int total = 0;
 

--- a/src/ui/relatorio/listagemDados.c
+++ b/src/ui/relatorio/listagemDados.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+
+#include "limparTela.h"
+#include "src/ui/aluno/cadastrarAluno.h"
+#include "src/ui/plano/cadastrarPlano.h"
+#include "src/ui/funcionario/cadastrarFuncionario.h"
+#include "src/ui/equipamento/cadastrarEquipamento.h"
+
+void relatorioListagemDados(void)
+{
+    limparTela();
+
+    printf("=========================================================================\n");
+    printf("===                 RELATÓRIO - LISTAGEM DE DADOS                     ===\n");
+    printf("=========================================================================\n\n");
+
+    int alunos_ativos = 0;
+    for (int i = 0; i < total_alunos; i++)
+    {
+        if (lista_alunos[i].ativo)
+        {
+            alunos_ativos++;
+        }
+    }
+    printf("ALUNOS ATIVOS: %d\n", alunos_ativos);
+    if (alunos_ativos > 0)
+    {
+        for (int i = 0; i < total_alunos; i++)
+        {
+            if (lista_alunos[i].ativo)
+            {
+                printf("  - [%s] %s\n", lista_alunos[i].id, lista_alunos[i].nome);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum aluno ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int planos_ativos = 0;
+    for (int i = 0; i < total_planos; i++)
+    {
+        if (lista_planos[i].ativo)
+        {
+            planos_ativos++;
+        }
+    }
+    printf("PLANOS ATIVOS: %d\n", planos_ativos);
+    if (planos_ativos > 0)
+    {
+        for (int i = 0; i < total_planos; i++)
+        {
+            if (lista_planos[i].ativo)
+            {
+                printf("  - [%s] %s\n", lista_planos[i].id, lista_planos[i].nome);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum plano ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int funcionarios_ativos = 0;
+    for (int i = 0; i < total_funcionarios; i++)
+    {
+        if (lista_funcionarios[i].ativo)
+        {
+            funcionarios_ativos++;
+        }
+    }
+    printf("FUNCIONÁRIOS ATIVOS: %d\n", funcionarios_ativos);
+    if (funcionarios_ativos > 0)
+    {
+        for (int i = 0; i < total_funcionarios; i++)
+        {
+            if (lista_funcionarios[i].ativo)
+            {
+                printf("  - [%s] %s (%s)\n", lista_funcionarios[i].id, lista_funcionarios[i].nome, lista_funcionarios[i].cargo);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum funcionário ativo encontrado.\n");
+    }
+
+    printf("\n");
+
+    int equipamentos_ativos = 0;
+    for (int i = 0; i < total_equipamentos; i++)
+    {
+        if (lista_equipamentos[i].ativo)
+        {
+            equipamentos_ativos++;
+        }
+    }
+    printf("EQUIPAMENTOS ATIVOS: %d\n", equipamentos_ativos);
+    if (equipamentos_ativos > 0)
+    {
+        for (int i = 0; i < total_equipamentos; i++)
+        {
+            if (lista_equipamentos[i].ativo)
+            {
+                printf("  - [%s] %s - Próx. manutenção: %s\n", lista_equipamentos[i].id, lista_equipamentos[i].nome, lista_equipamentos[i].proxima_manutencao);
+            }
+        }
+    }
+    else
+    {
+        printf("  Nenhum equipamento ativo encontrado.\n");
+    }
+
+    printf("\n=========================================================================\n");
+    printf(">>> Pressione <ENTER> para voltar...");
+    getchar();
+
+    limparTela();
+}

--- a/src/ui/relatorio/listagemDados.h
+++ b/src/ui/relatorio/listagemDados.h
@@ -1,0 +1,6 @@
+#ifndef LISTAGEM_DADOS_H
+#define LISTAGEM_DADOS_H
+
+void relatorioListagemDados(void);
+
+#endif

--- a/src/ui/relatorio/modRelatorio.c
+++ b/src/ui/relatorio/modRelatorio.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+#include "telaRelatorio.h"
+#include "listagemDados.h"
+#include "opInvalida.h"
+
+char moduloRelatorio(void)
+{
+    char op;
+
+    do
+    {
+        op = telaRelatorio();
+
+        switch (op)
+        {
+        case '1':
+            relatorioListagemDados();
+            break;
+
+        case '0':
+            break;
+
+        default:
+            opInvalida();
+            break;
+        }
+
+    } while (op != '0');
+
+    return op;
+}

--- a/src/ui/relatorio/telaRelatorio.c
+++ b/src/ui/relatorio/telaRelatorio.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+#include "limparTela.h"
+
+char telaRelatorio(void)
+{
+    char op;
+
+    printf("\n");
+    printf("=========================================================================\n");
+    printf("===                          RELATÓRIOS                               ===\n");
+    printf("=========================================================================\n");
+    printf("===                                                                   ===\n");
+    printf("===  [1]  RELATÓRIO DE LISTAGEM DE DADOS                              ===\n");
+    printf("===                                                                   ===\n");
+    printf("===  [0]  VOLTAR                                                      ===\n");
+    printf("===                                                                   ===\n");
+    printf("=========================================================================\n");
+    printf("=========================================================================\n");
+
+    scanf("%c", &op);
+    getchar();
+
+    limparTela();
+
+    return op;
+}

--- a/src/ui/relatorio/telaRelatorio.h
+++ b/src/ui/relatorio/telaRelatorio.h
@@ -1,0 +1,6 @@
+#ifndef TELA_RELATORIO_H
+#define TELA_RELATORIO_H
+
+char telaRelatorio(void);
+
+#endif

--- a/src/ui/telaPrincipal.c
+++ b/src/ui/telaPrincipal.c
@@ -16,7 +16,8 @@ char telaPrincipal(void)
     printf("===  [2]  PLANOS                                                      ===\n");
     printf("===  [3]  EQUIPAMENTOS                                                ===\n");
     printf("===  [4]  FUNCIONARIOS                                                ===\n");
-    printf("===  [5]  SOBRE                                                       ===\n");
+    printf("===  [5]  RELATORIOS                                                  ===\n");
+    printf("===  [6]  SOBRE                                                       ===\n");
     printf("===  [0]  SAIR                                                        ===\n");
     printf("===                                                                   ===\n");
     printf("=========================================================================\n");


### PR DESCRIPTION
## Summary
- seed fictitious alunos, planos, funcionários e equipamentos when the storage files are absent
- persist the seeded records so the relatório listagem displays meaningful sample data on first run

## Testing
- make

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691277ba3938832b9041dcafd9d45a3e)